### PR TITLE
MapEnvironmentContext.toString()

### DIFF
--- a/src/main/java/walkingkooka/environment/MapEnvironmentContext.java
+++ b/src/main/java/walkingkooka/environment/MapEnvironmentContext.java
@@ -22,6 +22,7 @@ import walkingkooka.collect.map.Maps;
 import walkingkooka.collect.set.Sets;
 import walkingkooka.collect.set.SortedSets;
 import walkingkooka.net.email.EmailAddress;
+import walkingkooka.text.CharSequences;
 import walkingkooka.text.LineEnding;
 
 import java.time.LocalDateTime;
@@ -214,6 +215,30 @@ final class MapEnvironmentContext implements EnvironmentContext {
 
     @Override
     public String toString() {
-        return this.values.toString();
+        final Map<EnvironmentValueName<?>, Object> map = Maps.sorted();
+        map.putAll(this.values);
+
+        map.put(
+            LINE_ENDING,
+            CharSequences.quoteAndEscape(
+                this.lineEnding()
+                    .toString()
+            )
+        );
+        map.put(
+            LOCALE,
+            this.locale()
+        );
+
+        final EmailAddress user = this.user()
+            .orElse(null);
+        if (null != user) {
+            map.put(
+                USER,
+                user
+            );
+        }
+
+        return map.toString();
     }
 }

--- a/src/test/java/walkingkooka/environment/MapEnvironmentContextTest.java
+++ b/src/test/java/walkingkooka/environment/MapEnvironmentContextTest.java
@@ -423,7 +423,26 @@ public final class MapEnvironmentContextTest implements EnvironmentContextTestin
 
         this.toStringAndCheck(
             context,
-            "{hello.123=Gday}"
+            "{hello.123=Gday, lineEnding=\"\\n\", locale=fr}"
+        );
+    }
+
+    @Test
+    public void testToStringWithUser() {
+        final MapEnvironmentContext context = MapEnvironmentContext.with(CONTEXT);
+        context.setEnvironmentValue(
+            NAME,
+            VALUE
+        );
+        context.setUser(
+            Optional.of(
+                EmailAddress.parse("user@example.com")
+            )
+        );
+
+        this.toStringAndCheck(
+            context,
+            "{hello.123=Gday, lineEnding=\"\\n\", locale=fr, user=user@example.com}"
         );
     }
 

--- a/src/test/java/walkingkooka/environment/ReadOnlyEnvironmentContextTest.java
+++ b/src/test/java/walkingkooka/environment/ReadOnlyEnvironmentContextTest.java
@@ -201,7 +201,7 @@ public final class ReadOnlyEnvironmentContextTest implements EnvironmentContextT
     public void testToString() {
         this.toStringAndCheck(
             this.createContext(),
-            "{locale=de}"
+            "{lineEnding=\"\\n\", locale=de}"
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-environment/issues/171
- MapEnvironmentContext.toString missing wrapped EnvironmentContext