### PR TITLE
EnvironmentValueName.registerConstant

### DIFF
--- a/src/main/java/walkingkooka/environment/EnvironmentValueName.java
+++ b/src/main/java/walkingkooka/environment/EnvironmentValueName.java
@@ -69,9 +69,13 @@ final public class EnvironmentValueName<T> implements Name,
 
     private final static Map<String, EnvironmentValueName<?>> CONSTANTS = Maps.sorted();
 
-    private static <T> EnvironmentValueName<T> registerConstant(final String name,
-                                                                final Class<T> type) {
-        final EnvironmentValueName<?> constant = new EnvironmentValueName<>(
+    /**
+     * Registers an {@link EnvironmentValueName} and its type. Note if an attempt is made to register a
+     * {@link EnvironmentValueName} with a different type an {@link IllegalArgumentException} will be thrown.
+     */
+    public static <T> EnvironmentValueName<T> registerConstant(final String name,
+                                                               final Class<T> type) {
+        final EnvironmentValueName<?> constant = with(
             name,
             type
         );

--- a/src/test/java/walkingkooka/environment/EnvironmentValueNameTest.java
+++ b/src/test/java/walkingkooka/environment/EnvironmentValueNameTest.java
@@ -156,6 +156,42 @@ final public class EnvironmentValueNameTest implements NameTesting2<EnvironmentV
         );
     }
 
+    // registerConstant.................................................................................................
+
+    @Test
+    public void testRegisterConstantWithDifferentType() {
+        final IllegalArgumentException thrown = assertThrows(
+            IllegalArgumentException.class,
+            () -> EnvironmentValueName.registerConstant(
+                "locale",
+                String.class
+            )
+        );
+
+        this.checkEquals(
+            "Invalid type \"java.lang.String\" expected \"java.util.Locale\"",
+            thrown.getMessage()
+        );
+    }
+
+    @Test
+    public void testRegisterConstantDuplicateNameAndType() {
+        final EnvironmentValueName<Locale> name = EnvironmentValueName.registerConstant(
+            "locale",
+            Locale.class
+        );
+
+        assertSame(
+            name,
+            EnvironmentValueName.registerConstant(
+                "locale",
+                Locale.class
+            )
+        );
+    }
+
+    // equals...........................................................................................................
+
     @Test
     public void testEqualsDifferentCase() {
         this.checkEqualsAndHashCode(


### PR DESCRIPTION
- Will help functions like setEnv "know" the correct type of the given EnvironmentValueName, because constants like SPREADSHEET_ID should have been previously registered as a constant.