### PR TITLE
EmptyEnvironmentContext.setEnvironmentValue throws ReadOnlyEnvironmen…

### DIFF
--- a/src/main/java/walkingkooka/environment/EmptyEnvironmentContext.java
+++ b/src/main/java/walkingkooka/environment/EmptyEnvironmentContext.java
@@ -138,7 +138,7 @@ final class EmptyEnvironmentContext implements EnvironmentContext,
                         Optional.of((EmailAddress) value)
                     );
                 } else {
-                    throw new UnsupportedOperationException();
+                    throw new ReadOnlyEnvironmentValueException(name);
                 }
             }
         }


### PR DESCRIPTION
…tValueException was UnsupportedOperationException