### PR TITLE
PropertiesEnvironmentContext.environmentValueNames FIX

### DIFF
--- a/src/main/java/walkingkooka/environment/PropertiesEnvironmentContext.java
+++ b/src/main/java/walkingkooka/environment/PropertiesEnvironmentContext.java
@@ -20,6 +20,7 @@ package walkingkooka.environment;
 import walkingkooka.Cast;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.collect.set.Sets;
+import walkingkooka.collect.set.SortedSets;
 import walkingkooka.net.email.EmailAddress;
 import walkingkooka.props.Properties;
 import walkingkooka.props.PropertiesPath;
@@ -122,25 +123,19 @@ final class PropertiesEnvironmentContext implements EnvironmentContext {
 
     @Override
     public Set<EnvironmentValueName<?>> environmentValueNames() {
-        if (null == this.names) {
-            final Set<EnvironmentValueName<?>> names = Sets.ordered();
+        final Set<EnvironmentValueName<?>> names = SortedSets.tree();
 
-            this.properties.keys()
-                .stream()
-                .map(p -> EnvironmentValueName.with(
-                        p.value(),
-                        String.class
-                    )
-                ).forEach(names::add);
+        this.properties.keys()
+            .stream()
+            .map(p -> EnvironmentValueName.with(
+                    p.value(),
+                    String.class
+                )
+            ).forEach(names::add);
 
-            names.add(LINE_ENDING);
-            names.add(LOCALE);
-            names.add(USER);
+        names.addAll(this.context.environmentValueNames());
 
-            this.names = Sets.immutable(names);
-        }
-
-        return this.names;
+        return Sets.immutable(names);
     }
 
     private Set<EnvironmentValueName<?>> names;

--- a/src/test/java/walkingkooka/environment/CollectionEnvironmentContextTest.java
+++ b/src/test/java/walkingkooka/environment/CollectionEnvironmentContextTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.HashCodeEqualsDefinedTesting2;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.collect.set.Sets;
 import walkingkooka.net.email.EmailAddress;
 import walkingkooka.props.Properties;
 import walkingkooka.props.PropertiesPath;
@@ -28,6 +29,7 @@ import walkingkooka.text.LineEnding;
 
 import java.time.LocalDateTime;
 import java.util.Locale;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -68,6 +70,16 @@ public final class CollectionEnvironmentContextTest implements EnvironmentContex
         @Override
         public Runnable addEventValueWatcherOnce(final EnvironmentValueWatcher watcher) {
             return () -> {};
+        }
+
+        @Override
+        public Set<EnvironmentValueName<?>> environmentValueNames() {
+            return Sets.of(
+                EnvironmentContext.LINE_ENDING,
+                EnvironmentContext.LOCALE,
+                EnvironmentContext.NOW,
+                EnvironmentValueName.USER
+            );
         }
     };
 
@@ -445,6 +457,7 @@ public final class CollectionEnvironmentContextTest implements EnvironmentContex
             ),
             EnvironmentContext.LINE_ENDING,
             EnvironmentContext.LOCALE,
+            EnvironmentContext.NOW,
             EnvironmentValueName.USER
         );
     }

--- a/src/test/java/walkingkooka/environment/PrefixedEnvironmentContextTest.java
+++ b/src/test/java/walkingkooka/environment/PrefixedEnvironmentContextTest.java
@@ -20,6 +20,7 @@ package walkingkooka.environment;
 import org.junit.jupiter.api.Test;
 import walkingkooka.HashCodeEqualsDefinedTesting2;
 import walkingkooka.ToStringTesting;
+import walkingkooka.collect.set.Sets;
 import walkingkooka.datetime.HasNow;
 import walkingkooka.net.email.EmailAddress;
 import walkingkooka.props.Properties;
@@ -29,6 +30,7 @@ import walkingkooka.text.LineEnding;
 import java.time.LocalDateTime;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -58,7 +60,12 @@ public final class PrefixedEnvironmentContextTest implements EnvironmentContextT
         EmailAddress.parse("user@example.com")
     );
 
-    private final static EnvironmentContext CONTEXT = EnvironmentContexts.fake();
+    private final static EnvironmentContext CONTEXT = new FakeEnvironmentContext() {
+        @Override
+        public Set<EnvironmentValueName<?>> environmentValueNames() {
+            return Sets.empty();
+        }
+    };
 
     @Test
     public void testWithNullPrefixFails() {

--- a/src/test/java/walkingkooka/environment/PropertiesEnvironmentContextTest.java
+++ b/src/test/java/walkingkooka/environment/PropertiesEnvironmentContextTest.java
@@ -211,7 +211,7 @@ public final class PropertiesEnvironmentContextTest implements EnvironmentContex
             ),
             EnvironmentContext.LINE_ENDING,
             EnvironmentContext.LOCALE,
-            EnvironmentValueName.USER
+            EnvironmentContext.NOW
         );
     }
 


### PR DESCRIPTION
- no longer caches name and merges with wrapped EnvironmentContext.