### PR TITLE
ReadOnlyEnvironmentContext.readOnlyNames Predicate

### DIFF
--- a/src/main/java/walkingkooka/environment/EnvironmentContexts.java
+++ b/src/main/java/walkingkooka/environment/EnvironmentContexts.java
@@ -26,6 +26,7 @@ import walkingkooka.text.LineEnding;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 /**
  * A collection of {@link EnvironmentContext} factory methods.
@@ -95,8 +96,12 @@ public final class EnvironmentContexts implements PublicStaticHelper {
     /**
      * {@see ReadOnlyEnvironmentContext}
      */
-    public static EnvironmentContext readOnly(final EnvironmentContext context) {
-        return ReadOnlyEnvironmentContext.with(context);
+    public static EnvironmentContext readOnly(final Predicate<EnvironmentValueName<?>> readOnlyNames,
+                                              final EnvironmentContext context) {
+        return ReadOnlyEnvironmentContext.with(
+            readOnlyNames,
+            context
+        );
     }
 
     /**

--- a/src/test/java/walkingkooka/environment/CollectionEnvironmentContextTest.java
+++ b/src/test/java/walkingkooka/environment/CollectionEnvironmentContextTest.java
@@ -23,6 +23,7 @@ import walkingkooka.HashCodeEqualsDefinedTesting2;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.set.Sets;
 import walkingkooka.net.email.EmailAddress;
+import walkingkooka.predicate.Predicates;
 import walkingkooka.props.Properties;
 import walkingkooka.props.PropertiesPath;
 import walkingkooka.text.LineEnding;
@@ -53,6 +54,7 @@ public final class CollectionEnvironmentContextTest implements EnvironmentContex
     private final static LocalDateTime NOW = LocalDateTime.MIN;
 
     private final static EnvironmentContext CONTEXT = EnvironmentContexts.readOnly(
+        Predicates.always(), // readOnlyNames
         EnvironmentContexts.empty(
             LINE_ENDING,
             LOCALE,


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-environment/issues/231
- ReadOnlyEnvironmentContext should take Predicate<EnvironmentValueName> to determine which values are readonly