### PR TITLE
EnvironmentContext.now() at timeOffset

### DIFF
--- a/src/main/java/walkingkooka/environment/EmptyEnvironmentContext.java
+++ b/src/main/java/walkingkooka/environment/EmptyEnvironmentContext.java
@@ -271,7 +271,9 @@ final class EmptyEnvironmentContext implements EnvironmentContext,
 
     @Override
     public LocalDateTime now() {
-        return this.hasNow.now();
+        return this.hasNow.now()
+            .atOffset(this.timeOffset())
+            .toLocalDateTime();
     }
 
     private final HasNow hasNow;

--- a/src/test/java/walkingkooka/environment/EmptyEnvironmentContextTest.java
+++ b/src/test/java/walkingkooka/environment/EmptyEnvironmentContextTest.java
@@ -421,6 +421,36 @@ public final class EmptyEnvironmentContextTest implements EnvironmentContextTest
         );
     }
 
+    // now..............................................................................................................
+
+    @Test
+    public void testNowAndZeroTimeOffset() {
+        final ZoneOffset zoneOffset = ZoneOffset.UTC;
+
+        final EmptyEnvironmentContext context = this.createContext();
+        context.setTimeOffset(zoneOffset);
+
+        this.checkEquals(
+            LocalDateTime.MIN.atOffset(zoneOffset)
+                .toLocalDateTime(),
+            context.now()
+        );
+    }
+
+    @Test
+    public void testNowAndNonZeroTimeOffset() {
+        final ZoneOffset zoneOffset = ZoneOffset.ofHours(2);
+
+        final EmptyEnvironmentContext context = this.createContext();
+        context.setTimeOffset(zoneOffset);
+
+        this.checkEquals(
+            LocalDateTime.MIN.atOffset(zoneOffset)
+                .toLocalDateTime(),
+            context.now()
+        );
+    }
+
     // equals...........................................................................................................
 
     @Test


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-environment/issues/259
- EnvironmentContext.NOW_OFFSET: offset added to clock LocalDateTime by now()